### PR TITLE
build: add commonjs package variant

### DIFF
--- a/c/package.json
+++ b/c/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "chartjs-chart-funnel",
+  "type": "commonjs",
+  "main": "../build/index.cjs",
+  "module": "../build/index.js",
+  "require": "../build/index.cjs",
+  "types": "../build/index.d.ts",
+  "sideEffects": false,
+  "peerDependencies": {
+    "chart.js": ">=3.7.0"
+  },
+  "dependencies": {
+    "@types/chroma-js": "^2.4.0",
+    "chroma-js": "^2.4.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -36,12 +36,14 @@
       "scripts": "./build/index.umd.min.js",
       "types": "./build/index.d.ts"
     },
-    "./.pnp.cjs": "./.pnp.cjs"
+    "./.pnp.cjs": "./.pnp.cjs",
+    "./c": "./c"
   },
   "sideEffects": false,
   "files": [
     "build",
-    "src/**/*.ts"
+    "src/**/*.ts",
+    "c"
   ],
   "peerDependencies": {
     "chart.js": ">=3.7.0"


### PR DESCRIPTION
add a commonjs package in `/c` that can be imported

```
import { FunnelController, TrapezoidElement } from 'chartjs-chart-funnel/c';
```